### PR TITLE
Makefile: added afl-showdsf.o target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,13 @@ afl-as: afl-as.c afl-as.h $(COMM_HDR) | test_x86
 	ln -sf afl-as as
 
 reducers.o: reducers.c $(COMM_HDR)
-	$(CC) $(CFLAGS) -c $^ 
+	$(CC) $(CFLAGS) -c $^
 
 afl-fuzz.o: afl-fuzz.c $(COMM_HDR)
 	$(CC) $(CFLAGS) -c $^ 
+
+afl-showdsf.o: afl-showdsf.c $(COMM_HDR)
+	$(CC) $(CFLAGS) -c $^
 
 afl-fuzz: afl-fuzz.o reducers.o | test_x86
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
@@ -81,7 +84,7 @@ afl-fuzz: afl-fuzz.o reducers.o | test_x86
 afl-showmap: afl-showmap.c $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS)
 
-afl-showdsf: afl-showdsf.c reducers.o $(COMM_HDR) | test_x86
+afl-showdsf: afl-showdsf.o reducers.o | test_x86
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 afl-tmin: afl-tmin.c $(COMM_HDR) | test_x86


### PR DESCRIPTION
Hey Rohan and Caroline,

I was getting the following error when trying to build (with clang 7.1.0):

```
cc -O3 -funroll-loops -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign -DAFL_PATH=\"/usr/local/lib/afl\" -DDOC_PATH=\"/usr/local/share/doc/afl\" -DBIN_PATH=\"/usr/local/bin\" -Iinclude afl-showdsf.c reducers.o alloc-inl.h config.h debug.h types.h -o afl-showdsf -ldl
clang: error: cannot specify -o when generating multiple output files
Makefile:85: recipe for target 'afl-showdsf' failed
```

So I added an extra afl-showdsf.o target and it all builds fine.