### PR TITLE
Fixes for compatibility with clang-10

### DIFF
--- a/llvm_mode/Makefile
+++ b/llvm_mode/Makefile
@@ -108,7 +108,7 @@ endif
 test_build: $(PROGS)
 	@echo "[*] Testing the CC wrapper and instrumentation output..."
 	unset AFL_USE_ASAN AFL_USE_MSAN AFL_INST_RATIO; AFL_QUIET=1 AFL_PATH=. AFL_CC=$(CC) ../afl-clang-fast $(CFLAGS) ../test-instr.c -o test-instr $(LDFLAGS)
-	echo 0 | ../afl-showmap -m none -q -o .test-instr0 ./test-instr
+	../afl-showmap -m none -q -o .test-instr0 ./test-instr < /dev/null
 	echo 1 | ../afl-showmap -m none -q -o .test-instr1 ./test-instr
 	@rm -f test-instr
 	@cmp -s .test-instr0 .test-instr1; DR="$$?"; rm -f .test-instr0 .test-instr1; if [ "$$DR" = "0" ]; then echo; echo "Oops, the instrumentation does not seem to be behaving correctly!"; echo; echo "Please ping <lcamtuf@google.com> to troubleshoot the issue."; echo; exit 1; fi

--- a/llvm_mode/fuzzfactory.hpp
+++ b/llvm_mode/fuzzfactory.hpp
@@ -39,8 +39,8 @@ public:
 
     /** Instatiates a new domain and immediately registered the instrumentation pass with LLVM */
     RegisterDomain() : ModulePass(RegisterDomain<D>::ID) {
-        RegisterStandardPasses RegisterFuzzFactoryPass(PassManagerBuilder::EP_OptimizerLast, RegisterDomain<D>::registerPass);
-        RegisterStandardPasses RegisterFuzzFactoryPass0(PassManagerBuilder::EP_EnabledOnOptLevel0, RegisterDomain<D>::registerPass);    
+        static RegisterStandardPasses RegisterFuzzFactoryPass(PassManagerBuilder::EP_OptimizerLast, RegisterDomain<D>::registerPass);
+        static RegisterStandardPasses RegisterFuzzFactoryPass0(PassManagerBuilder::EP_EnabledOnOptLevel0, RegisterDomain<D>::registerPass);
     }
 
     /* Runs this instrumentation pass on a module */

--- a/llvm_mode/waypoints-diff-pass.cc
+++ b/llvm_mode/waypoints-diff-pass.cc
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/Support/CommandLine.h"
 #include "fuzzfactory.hpp"
 
 using namespace fuzzfactory;


### PR DESCRIPTION
I had issues compiling FuzzFactory with clang/llvm-10. In particular, the domain-specific-feedback passes did not seem to be registered, so no domain-specific feedback was ever added. 

I've tried compiling `demo` with these changes and clang-6, and everything seems in order, but just wanted to sanity-check with you before pushing to master. 