### PR TITLE
Fix dsf map initialization

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2457,6 +2457,15 @@ static u8 run_target(char** argv, u32 timeout) {
   memset(trace_bits, 0, MAP_SIZE);
   if (dsf_enabled || save_everything) { 
     memset(dsf_map, 0, dsf_len_actual * sizeof(u32));
+    for (int i = 0; i < dsf_count; i++) {
+      u32 dsf_initial = dsf_configs[i].initial;
+      if (dsf_initial == 0) continue;
+      int dsf_start = dsf_configs[i].start;
+      int dsf_end = dsf_configs[i].end;
+      for (int j = dsf_start; j < dsf_end; j++) {
+        dsf_map[j] = dsf_initial;
+      }
+    }
   }
   MEM_BARRIER();
 

--- a/afl-showdsf.c
+++ b/afl-showdsf.c
@@ -569,7 +569,17 @@ static void run_target() {
 
   memset(trace_bits, 0, MAP_SIZE);
   memset(dsf_map, 0, dsf_len_actual * sizeof(u32));
-  
+
+  for (int i = 0; i < dsf_count; i++) {
+    u32 dsf_initial = dsf_configs[i].initial;
+    if (dsf_initial == 0) continue;
+    int dsf_start = dsf_configs[i].start;
+    int dsf_end = dsf_configs[i].end;
+    for (int j = dsf_start; j < dsf_end; j++) {
+      dsf_map[j] = dsf_initial;
+    }
+  }
+
   if (!quiet_mode)
     SAYF(cRST "-- Program output begins --\n");
 


### PR DESCRIPTION
When initializing `dsf_map` for each target run, `dsf_map` should be set to `dsf_configs[i].initial` if the initial aggregate value `dsf_initial` is not zero.